### PR TITLE
feat: add Codex CLI support via .codex/AGENTS.md

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,225 @@
+# Accessibility Agents — Codex CLI
+
+This project enforces WCAG 2.2 AA accessibility. When writing or modifying any
+web UI code — HTML, JSX, TSX, Vue, Svelte, CSS, or any user-facing component —
+you must apply the rules below before considering the work done.
+
+> These rules are derived from the [Accessibility Agents](https://github.com/Community-Access/accessibility-agents)
+> project, a community initiative ensuring AI coding tools stop generating
+> inaccessible code by default.
+
+---
+
+## Pre-flight: Is This a UI Task?
+
+If the file or prompt involves **HTML, JSX/TSX, CSS, Vue, Svelte, forms,
+modals, tables, images, interactive components, or any visual output**, treat
+it as a UI task. Apply the relevant sections below. Do not skip this even if
+the user does not ask for an accessibility review.
+
+---
+
+## 1. ARIA — Use It Correctly or Not At All
+
+**First rule:** If native HTML expresses the semantics, do not add ARIA.
+A `<button>` beats `<div role="button">` every time.
+
+**Never add ARIA to these** (they already have implicit roles):
+- `<header>`, `<nav>`, `<main>`, `<footer>`, `<aside>`
+- `<button>`, `<a href>`, `<input>`, `<select>`, `<textarea>`
+- `<h1>`–`<h6>`, `<ul>`, `<ol>`, `<li>`, `<table>`, `<form>`
+
+**Always required:**
+- Every interactive element needs an accessible name:
+  `aria-label`, `aria-labelledby`, or visible text.
+- Icon-only buttons: `<button aria-label="Close">` — not empty.
+- Multiple `<nav>` elements on one page: each needs `aria-label`.
+- Images: `alt=""` for decorative, meaningful alt text for informative.
+  Never use the filename as alt text.
+
+**State attributes — keep them live:**
+- Toggle buttons: `aria-pressed="true/false"` (must update on click)
+- Expandable sections: `aria-expanded="true/false"` on the trigger
+- Invalid inputs: `aria-invalid="true"` + `aria-describedby` pointing to error message
+- Loading: `aria-busy="true"` on the region being updated
+- Required fields: `aria-required="true"` or native `required`
+
+---
+
+## 2. Keyboard Navigation
+
+Every interactive element must be reachable and operable by keyboard alone.
+
+**Focus management rules:**
+- Tab order must follow visual/reading order — never use `tabindex > 0`.
+- Use `tabindex="0"` only to make non-interactive elements focusable when necessary.
+- Use `tabindex="-1"` for elements you manage focus to programmatically.
+- Focus must be visible at all times — never `outline: none` without a custom
+  focus style with ≥3:1 contrast against the background.
+
+**Keyboard patterns for common components:**
+
+| Component | Keys |
+|-----------|------|
+| Button | `Enter`, `Space` |
+| Link | `Enter` |
+| Checkbox | `Space` to toggle |
+| Radio group | `Arrow` keys to move, `Tab` to exit group |
+| Select / listbox | `Arrow` keys to navigate, `Enter` to select |
+| Tabs | `Arrow` keys between tabs, `Tab` into panel |
+| Modal | `Tab`/`Shift+Tab` trapped inside, `Escape` closes |
+| Menu | `Arrow` keys to navigate, `Escape` closes, `Enter`/`Space` selects |
+| Combobox | `Arrow` keys in list, `Escape` collapses, `Enter` selects |
+
+**Focus trap in modals:** When a modal opens, focus must move inside it.
+When it closes, focus must return to the trigger element.
+
+---
+
+## 3. Modals and Dialogs
+
+```html
+<dialog aria-modal="true" aria-labelledby="dialog-title">
+  <button aria-label="Close dialog">✕</button>
+  <h2 id="dialog-title">Dialog Title</h2>
+  <!-- content -->
+</dialog>
+```
+
+Requirements:
+- `aria-modal="true"` and `aria-labelledby` on `<dialog>`
+- Close button is the **first focusable element** inside
+- Focus moves **into** the dialog on open
+- `Escape` closes and returns focus to the trigger
+- Background content is `inert` or `aria-hidden="true"` while modal is open
+- Heading starts at H2 (H1 is reserved for the page)
+
+---
+
+## 4. Forms
+
+```html
+<div>
+  <label for="email">Email address</label>
+  <input id="email" type="email" aria-required="true"
+         aria-describedby="email-error email-hint" />
+  <span id="email-hint">We will never share your email.</span>
+  <span id="email-error" role="alert" aria-live="polite"></span>
+</div>
+```
+
+Rules:
+- Every `<input>`, `<select>`, `<textarea>` must have a visible `<label>`.
+  No placeholder-only labels — placeholder disappears on focus.
+- Error messages must be announced: `role="alert"` or `aria-live="polite"`.
+- Error message must be linked to the field via `aria-describedby`.
+- Group related inputs in `<fieldset>` with `<legend>` (radio/checkbox groups).
+- On submit failure: move focus to the first error or an error summary at the top.
+- Do not disable the submit button to indicate errors — show messages instead.
+
+---
+
+## 5. Color Contrast
+
+- Normal text (< 18pt / 14pt bold): **4.5:1** minimum against background
+- Large text (≥ 18pt / 14pt bold): **3:1** minimum
+- UI components and focus indicators: **3:1** against adjacent colors
+- Never convey information with color alone — pair with text, icon, or pattern
+
+**Never assume a color passes.** Use values or reference your design tokens.
+If the contrast ratio is unknown, flag it with a comment for human verification.
+
+---
+
+## 6. Dynamic Content and Live Regions
+
+When content updates without a page reload, screen readers must be notified.
+
+```html
+<!-- Status messages (non-urgent) -->
+<div aria-live="polite" aria-atomic="true"></div>
+
+<!-- Urgent alerts -->
+<div role="alert"></div>
+
+<!-- Loading state -->
+<div aria-busy="true" aria-live="polite">Loading results…</div>
+```
+
+Rules:
+- `aria-live="polite"` for status updates (toasts, search results, counts)
+- `role="alert"` (implies `aria-live="assertive"`) for errors only
+- Live regions must be in the DOM **before** content is injected — do not
+  create and populate them in the same tick
+- `aria-atomic="true"` when the whole region should be read as one unit
+
+---
+
+## 7. Heading Structure and Landmarks
+
+- One `<h1>` per page — the page title or main content title
+- Headings must be hierarchical: never skip from H2 to H4
+- Use headings for structure, not for styling — use CSS for visual size
+- Landmark regions: `<header>`, `<nav>`, `<main>`, `<footer>`, `<aside>`
+- Page must have exactly one `<main>`
+- Every page needs a `<title>` that describes its unique content
+
+---
+
+## 8. Images
+
+- Informative images: meaningful `alt` text describing content or function
+- Decorative images: `alt=""` (empty string, not omitted)
+- Functional images (buttons/links): alt describes the action, not the image
+- Complex images (charts, graphs): provide a text alternative or `<figcaption>`
+- Never use the filename, "image of", or "photo of" as alt text
+
+---
+
+## 9. Tables
+
+Data tables only — never use tables for layout.
+
+```html
+<table>
+  <caption>Monthly sales by region</caption>
+  <thead>
+    <tr>
+      <th scope="col">Region</th>
+      <th scope="col">Q1</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">North</th>
+      <td>$42,000</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+- `<caption>` describes the table purpose
+- `<th scope="col">` for column headers, `<th scope="row">` for row headers
+- Complex tables: use `id` on headers and `headers` attribute on cells
+
+---
+
+## 10. Pre-Commit Checklist
+
+Before completing any UI task, verify:
+
+- [ ] All interactive elements have accessible names
+- [ ] Tab order is logical; no positive `tabindex`
+- [ ] Focus is visible on every focusable element
+- [ ] All form fields have visible, programmatically associated labels
+- [ ] Error messages are linked to fields and announced to screen readers
+- [ ] Modals trap focus and return it on close
+- [ ] Dynamic updates use live regions
+- [ ] No color-only information conveyance
+- [ ] Heading hierarchy is valid (no skipped levels)
+- [ ] Images have appropriate alt text
+- [ ] ARIA is not used where native HTML suffices
+- [ ] All ARIA state attributes update dynamically
+
+If any item cannot be verified from the code alone, add a `<!-- a11y: needs
+manual verification — [reason] -->` comment so it is not silently dropped.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All agents run on:
 - **Claude Code** - Agents you invoke directly for accessibility evaluation
 - **GitHub Copilot** - Agents + workspace instructions that ensure accessibility guidance in every conversation
 - **Claude Desktop** - An MCP extension (.mcpb) with tools and prompts for accessibility review
+- **Codex CLI** - Condensed WCAG AA rules loaded via `.codex/AGENTS.md` — accessibility enforced automatically on every UI task
 
 ## Quick Start
 
@@ -134,7 +135,7 @@ The following guides cover web and document accessibility features.
 
 | Guide | What It Covers |
 |-------|---------------|
-| [Getting Started](docs/getting-started.md) | Installation for Claude Code, Copilot, and Claude Desktop |
+| [Getting Started](docs/getting-started.md) | Installation for Claude Code, Copilot, Claude Desktop, and Codex CLI |
 | [Agent Reference](docs/agents/README.md) | All 22 agents with invocation syntax, examples, and deep dives |
 | [MCP Tools](docs/tools/mcp-tools.md) | Static analysis tools: heading structure, link text, form labels |
 | [axe-core Integration](docs/tools/axe-core-integration.md) | Runtime scanning, agent workflow, CI/CD setup |


### PR DESCRIPTION
## Summary

Adds first-pass Codex CLI support to the accessibility-agents project.

## What's included

### `.codex/AGENTS.md`
Condensed WCAG 2.2 AA rules for Codex CLI, covering:
- ARIA (first rule, never-add list, required states)
- Keyboard navigation (tab order, focus visibility, component patterns)
- Modals and dialogs (focus trap, Escape, `aria-modal`)
- Forms (visible labels, error linking, live announcements)
- Color contrast (4.5:1 / 3:1 thresholds, no color-only info)
- Dynamic content and live regions (polite vs assertive, pre-population rule)
- Heading structure and landmarks (`<main>`, hierarchy)
- Images (informative vs decorative alt text)
- Tables (`<caption>`, `<th scope>`)
- Pre-commit checklist Codex runs before completing any UI task

### `install.sh`
New `--codex` flag and interactive prompt. Merges `.codex/AGENTS.md` into `.codex/AGENTS.md` (project install) or `~/.codex/AGENTS.md` (global install) using the same section-marker approach used for Copilot config files — never overwrites user content.

### `README.md`
Codex CLI listed alongside Claude Code, Copilot, and Claude Desktop in the supported platforms section.

## How it works

Codex CLI reads `AGENTS.md` files from the project directory tree automatically. The `.codex/AGENTS.md` file is picked up on every run — no extra flags needed.

## Tested

Verified against a test page with 10 planted accessibility violations (unlabeled inputs, icon-only buttons with no name, heading skip, filename alt text, unfocused modal, onclick divs, color-only error state, same-tick live region, table with no headers, broken tab pattern). Codex caught all 10 plus 3 more, each mapped back to a named rule in AGENTS.md.

## Notes

- Single-document approach — Codex has no sub-agent concept like Claude Code
- Rules condensed for context efficiency while covering all major WCAG domains
- Same `<!-- a11y-agent-team: start/end -->` markers for safe merging

## Author

@Orinks — NVDA and VoiceOver user, building accessible Windows/macOS apps. Wanted this for personal projects and figured the community should have it too.