### PR TITLE
fix: use exact match instead of glob in a11y-mark-reviewed.sh

### DIFF
--- a/claude-code-plugin/scripts/a11y-mark-reviewed.sh
+++ b/claude-code-plugin/scripts/a11y-mark-reviewed.sh
@@ -22,7 +22,7 @@ print('SESSION_ID=' + repr(session_id))
 # If this was an accessibility-lead agent call, create the marker
 if [ -n "$SESSION_ID" ]; then
   case "$SUBAGENT" in
-    *accessibility-lead*|*accessibility-agents:accessibility-lead*)
+    accessibility-agents:accessibility-lead|accessibility-lead)
       touch "/tmp/a11y-reviewed-${SESSION_ID}"
       ;;
   esac


### PR DESCRIPTION
## Summary

- The `*accessibility-lead*` glob pattern in the `case` statement on line 25 of `a11y-mark-reviewed.sh` is a superset of the `*accessibility-agents:accessibility-lead*` alternative, making the second branch dead code
- The glob matches any `subagent_type` containing the substring "accessibility-lead", which could create the session marker (and unlock the edit gate) without the intended plugin agent being invoked
- Replaced both globs with exact string matches for the two valid `subagent_type` values: `accessibility-agents:accessibility-lead` (plugin-qualified) and `accessibility-lead` (bare name that Claude Code resolves to the same agent)

## Test plan

- [ ] Install the plugin and verify the PostToolUse hook loads
- [ ] Invoke `accessibility-agents:accessibility-lead` via the Agent tool and confirm the `/tmp/a11y-reviewed-*` marker is created
- [ ] Invoke `accessibility-lead` (bare name) and confirm the marker is also created
- [ ] Invoke an unrelated agent whose `subagent_type` contains "accessibility-lead" as a substring and confirm the marker is NOT created

Generated with [Claude Code](https://claude.com/claude-code)