### PR TITLE
fix: initialize installer manifest helper before codex install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -197,6 +197,18 @@ case "$choice" in
     ;;
 esac
 
+# Manifest: track which files we install so updates never touch user-created files.
+# Keep the helper global so later install paths (Copilot/Codex/Gemini) can always use it,
+# including global/plugin installs that bypass the Claude file-copy branch.
+mkdir -p "$TARGET_DIR"
+MANIFEST_FILE="$TARGET_DIR/.a11y-agent-manifest"
+touch "$MANIFEST_FILE"
+
+add_manifest_entry() {
+  local entry="$1"
+  grep -qxF "$entry" "$MANIFEST_FILE" 2>/dev/null || echo "$entry" >> "$MANIFEST_FILE"
+}
+
 # ---------------------------------------------------------------------------
 # merge_config_file src dst label
 # Appends/updates our section in a config markdown file using section markers.
@@ -759,15 +771,6 @@ mkdir -p "$TARGET_DIR/agents"
 if [ ${#SKILLS[@]} -gt 0 ]; then
   mkdir -p "$TARGET_DIR/skills"
 fi
-
-# Manifest: track which files we install so updates never touch user-created files
-MANIFEST_FILE="$TARGET_DIR/.a11y-agent-manifest"
-touch "$MANIFEST_FILE"
-
-add_manifest_entry() {
-  local entry="$1"
-  grep -qxF "$entry" "$MANIFEST_FILE" 2>/dev/null || echo "$entry" >> "$MANIFEST_FILE"
-}
 
 # Copy agents — skip any file that already exists (preserves user customisations)
 echo ""
@@ -1846,4 +1849,3 @@ echo ""
 echo "  Start Claude Code and try: \"Build a login form\""
 echo "  The accessibility-lead should activate automatically."
 echo ""
-


### PR DESCRIPTION
## Summary
- fix the installer bug where `install.sh --global --codex` could fail with `add_manifest_entry: command not found`
- initialize the manifest helper before any installer path can call it
- ensure fresh global installs create the target directory before touching the manifest

## Root cause
The Codex install path called `add_manifest_entry`, but that helper was defined later inside the Claude file-copy branch. On global/plugin installs, that branch was skipped, so the function never existed when Codex tried to use it.

Moving the helper earlier exposed a second issue on fresh global installs: the target directory needed to be created before the manifest file could be touched.

## Verification
I verified the relevant installer paths against this branch non-interactively:
- `bash install.sh --global`
- `bash install.sh --project`
- `bash install.sh --global --codex`
- `bash install.sh --project --codex`
- `bash install.sh --global --gemini`
- `bash install.sh --project --gemini`
- `bash install.sh --global --cli`
- `bash install.sh --project --cli`

All eight completed with exit status 0.

For the Codex paths, I also verified that the install produced:
- `.codex/AGENTS.md`
- `.codex/config.toml`
- `.codex/roles/` with all role files
- correct manifest entries for Codex config, roles, install scope, and AGENTS path

## Scope
Tight fix to installer execution order and target-dir initialization only. No unrelated cleanup.