### PR TITLE
docs: route contributors to Community-Access/support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,16 @@ Thank you for considering a contribution. This is a community-driven project, an
 
 A sincere thanks goes out to [Taylor Arndt](https://github.com/taylorarndt) and [Jeff Bishop](https://github.com/jeffreybishop) for leading the charge in building this project. Now we want more contributors to help us make more magic. Whether you are a developer, accessibility specialist, screen reader user, or someone who just cares about inclusive software - your contributions are welcome here.
 
+## Support and Community Routing
+
+Use the Community Access support hub for cross-project troubleshooting and Q&A:
+
+- Support hub home: https://github.com/Community-Access/support
+- Discussions: https://github.com/Community-Access/support/discussions
+- Issues: https://github.com/Community-Access/support/issues
+
+Use this repository issue tracker for Accessibility Agents-specific bugs and feature requests.
+
 ## Ways to Contribute
 
 ### Report agent gaps

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ A sincere thanks goes out to [Taylor Arndt](https://github.com/taylorarndt) and 
 
 > **We want more contributors!** If you care about making software accessible to blind and low vision users, please consider [submitting a PR](CONTRIBUTING.md). Every improvement to these agents helps developers ship more inclusive software for the people who need it most.
 
+## Support Hub
+
+For troubleshooting, Q&A, and community support across workshop and agent ecosystems, use the Community Access support repository:
+
+- Home: https://github.com/Community-Access/support
+- Discussions: https://github.com/Community-Access/support/discussions
+- Issues: https://github.com/Community-Access/support/issues
+
+Related repositories:
+
+- Workshop curriculum: https://github.com/Community-Access/git-going-with-github
+- Accessibility Agents source: https://github.com/Community-Access/accessibility-agents
+
 ---
 
 ## The Problem


### PR DESCRIPTION
Updates README and CONTRIBUTING to reference the canonical support repository (Community-Access/support), including direct links to Discussions and Issues and cross-links to workshop curriculum.\n\nThis aligns support routing across Community Access repositories.