### PR TITLE
fix(codex): route accessibility dispatch by project surface

### DIFF
--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -58,11 +58,11 @@ The router layer is intentionally small. Specialist knowledge stays available wi
 The plugin includes Codex lifecycle hook files for the universal installer to
 register as a single user-level guard for UI work:
 
-- `UserPromptSubmit` detects UI and web prompts and injects the lead-dispatch requirement.
-- `SubagentStart` records when `accessibility-lead` and tracked web specialists have started for the current turn.
-- `SubagentStop` records when `accessibility-lead` and tracked web specialists have completed for the current turn.
-- `PreToolUse` blocks edits to UI files until `accessibility-lead` has been dispatched in that same turn.
-- `Stop` blocks final answers until `accessibility-lead` and required specialists have completed.
+- `UserPromptSubmit` classifies the workspace and task context, then injects the relevant routing requirement. It recognizes web, desktop/native Python, Office/PDF/EPUB, and markdown surfaces; an explicit task target takes precedence over ambient workspace evidence.
+- `SubagentStart` records when selected web, desktop, document, and markdown specialists have started for the current turn.
+- `SubagentStop` records when selected web, desktop, document, and markdown specialists have completed for the current turn.
+- `PreToolUse` blocks relevant web, desktop, document, or markdown edits until that surface's coordinator has been dispatched in the same turn.
+- `Stop` blocks final answers until the selected coordinator and required specialists have completed.
 
 This is intentionally paired with the router skill. The hook enforces the rule at the edit boundary, while the router still owns the dispatch plan and specialist selection. If Codex has lazy-loaded the subagent tool, the router must use `tool_search` before claiming subagents are unavailable.
 
@@ -179,11 +179,15 @@ After installing or updating Codex subagents or hooks, start a new Codex session
 
 If Codex shows a hooks review notice, open `/hooks`, review the Accessibility Agents entries that run `a11y-codex-dispatch-guard.mjs`, and trust them.
 
-The Codex hook guard now tracks the full UI review lifecycle. It injects the
-lead-plus-specialists requirement for UI prompts, records `SubagentStart` and
-`SubagentStop` for the lead and tracked web specialists, blocks UI edits until
-the lead has started, and blocks the final answer until the lead and required
-specialists have completed.
+The Codex hook guard now tracks the full accessibility-review lifecycle. It
+uses bounded workspace evidence (project manifests and a shallow file scan) to
+choose the matching router and specialists. Web projects retain the existing
+lead-plus-web-specialist coverage. Desktop Python projects use desktop,
+keyboard, and screen-reader testing specialists rather than web-only reviews;
+document and markdown projects route to their respective leads. It records
+`SubagentStart` and `SubagentStop`, blocks UI edits until the required review
+has started, and blocks the final answer until the required specialists have
+completed.
 
 ## Expected User Experience
 

--- a/codex-plugin/hooks/a11y-codex-dispatch-guard.mjs
+++ b/codex-plugin/hooks/a11y-codex-dispatch-guard.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 const input = await readJsonFromStdin();
 const eventName = input.hook_event_name || input.hookEventName || "";
@@ -40,14 +40,17 @@ async function readJsonFromStdin() {
 
 function handleUserPrompt(input) {
   const prompt = String(input.prompt || "");
-  if (!requiresAccessibilityDispatch(prompt)) {
+  const surface = detectProjectSurface(input, prompt);
+  if (!requiresAccessibilityDispatch(prompt, surface)) {
     return;
   }
-  const requiredSpecialists = selectRequiredSpecialists(prompt);
+  const requiredSpecialists = selectRequiredSpecialists(prompt, surface);
   writeTurnState({
     sessionId: input.session_id || null,
     turnId: input.turn_id || null,
     prompt,
+    surface,
+    coordinator: surface.coordinator,
     requiredSpecialists,
     recordedAt: new Date().toISOString()
   });
@@ -55,11 +58,11 @@ function handleUserPrompt(input) {
     hookSpecificOutput: {
       hookEventName: "UserPromptSubmit",
       additionalContext: [
-        "Accessibility Agents Codex dispatch is required for this UI/web task.",
-        `Before editing UI files, use the web-accessibility router and spawn accessibility-lead plus these required specialists: ${requiredSpecialists.join(", ")}.`,
+        "Accessibility Agents Codex dispatch is required for this accessibility task.",
+        `Detected project surface: ${surface.primary}. Before editing relevant files, use the ${surface.router} router and spawn ${surface.coordinator} as coordinator plus these required specialists: ${requiredSpecialists.join(", ")}.`,
         "If the subagent tool is not visible, call tool_search for multi-agent subagent accessibility.",
         "Do not continue with a local-only accessibility review unless the user explicitly overrides this requirement.",
-        "Before finalizing, wait for accessibility-lead and every required specialist to complete, then synthesize their findings."
+        `Before finalizing, wait for ${surface.coordinator} and every required specialist to complete, then synthesize their findings.`
       ].join(" ")
     }
   });
@@ -87,11 +90,11 @@ function handleSubagentLifecycle(input, state) {
 }
 
 function handlePreToolUse(input) {
-  if (!touchesUiFile(input.tool_input)) {
+  const turn = readTurnState();
+  if (!turn || !touchesRelevantFile(input.tool_input, turn.surface?.primary)) {
     return;
   }
-  const turn = readTurnState();
-  if (hasAgentStateSince(input, "accessibility-lead", "started", turn?.recordedAt)) {
+  if (hasAgentStateSince(input, turn.coordinator || "accessibility-lead", "started", turn.recordedAt)) {
     return;
   }
   writeJson({
@@ -100,7 +103,7 @@ function handlePreToolUse(input) {
       permissionDecision: "deny",
       permissionDecisionReason: [
         "Accessibility Agents dispatch is required before editing UI files.",
-        "Spawn accessibility-lead first for this turn, using tool_search if the subagent tool is lazy-loaded, then retry the edit."
+        `Spawn ${turn.coordinator || "accessibility-lead"} first for this turn, using tool_search if the subagent tool is lazy-loaded, then retry the edit.`
       ].join(" ")
     }
   });
@@ -113,8 +116,9 @@ function handleStop(input) {
   }
   const requiredSpecialists = Array.isArray(turn.requiredSpecialists) ? turn.requiredSpecialists : [];
   const missing = [];
-  if (!hasAgentStateSince(input, "accessibility-lead", "completed", turn.recordedAt)) {
-    missing.push("accessibility-lead completion");
+  const coordinator = turn.coordinator || "accessibility-lead";
+  if (!hasAgentStateSince(input, coordinator, "completed", turn.recordedAt)) {
+    missing.push(`${coordinator} completion`);
   }
   for (const specialist of requiredSpecialists) {
     if (!hasAgentStateSince(input, specialist, "completed", turn.recordedAt)) {
@@ -127,32 +131,64 @@ function handleStop(input) {
   writeJson({
     decision: "block",
     reason: [
-      "Accessibility Agents review is not complete for this UI/web task.",
+      "Accessibility Agents review is not complete for this accessibility task.",
       `Wait for or spawn the missing reviews: ${missing.join(", ")}.`,
-      "If nested dispatch was unavailable, the root session must spawn accessibility-lead and the required specialists directly, wait for all of them, then provide the lead synthesis before finalizing."
+      `If nested dispatch was unavailable, the root session must spawn ${coordinator} and the required specialists directly, wait for all of them, then provide the coordinator synthesis before finalizing.`
     ].join(" ")
   });
 }
 
-function touchesUiFile(toolInput) {
+function touchesRelevantFile(toolInput, surface) {
   const text = JSON.stringify(toolInput || {});
-  const filePatterns = [
+  const webPatterns = [
     /(?:^|[/"'` ])(?:app|pages|src|components|layouts|views|routes)\/[^"'`\n]*(?:\.jsx|\.tsx|\.vue|\.svelte|\.astro|\.css|\.scss|\.sass|\.less|\.html)\b/i,
     /(?:^|[/"'` ])[^"'`\n]*(?:\.jsx|\.tsx|\.vue|\.svelte|\.astro|\.css|\.scss|\.sass|\.less|\.html)\b/i,
     /\*\*\* (?:Add|Update) File: [^\n]*(?:\.jsx|\.tsx|\.vue|\.svelte|\.astro|\.css|\.scss|\.sass|\.less|\.html)\b/i
   ];
-  return filePatterns.some((pattern) => pattern.test(text));
+  if (surface === "desktop") {
+    return /(?:^|[/'` ])[^"'`\n]*\.(?:py|pyw|cs|cpp|cxx|java|kt|swift|rs)\b/i.test(text);
+  }
+  if (surface === "documents") {
+    return /(?:^|[/'` ])[^"'`\n]*\.(?:docx|xlsx|pptx|pdf|epub)\b/i.test(text);
+  }
+  if (surface === "markdown") {
+    return /(?:^|[/'` ])[^"'`\n]*\.md\b/i.test(text);
+  }
+  return webPatterns.some((pattern) => pattern.test(text));
 }
 
 function looksLikeUiWork(prompt) {
-  return /\b(ui|user interface|frontend|front-end|react|next\.?js|vue|svelte|astro|html|css|jsx|tsx|component|modal|dialog|form|button|link|menu|navigation|page|screen|layout|aria|keyboard|focus|contrast|wcag|accessib)/i.test(prompt);
+  return /\b(ui|user interface|frontend|front-end|react|next\.?js|vue|svelte|astro|html|css|jsx|tsx|component|modal|dialog|form|button|link|menu|navigation|page|screen|layout|aria|keyboard|focus|contrast|wcag|accessib\w*|screen reader|nvda|jaws|voiceover|pdf|docx|xlsx|pptx|epub|markdown|readme|heading|alt text)\b/i.test(prompt);
 }
 
-function requiresAccessibilityDispatch(prompt) {
-  return looksLikeUiWork(prompt) && /\b(add|build|create|make|implement|edit|update|change|fix|remove|refactor|review|audit|check|test|verify|ship|find|scan|inspect|look for|search for|homepage|component|page|modal|dialog|form|button|link|menu|navigation|layout)\b/i.test(prompt);
+function requiresAccessibilityDispatch(prompt, surface) {
+  const isAction = /\b(add|build|create|make|implement|edit|update|change|fix|remove|refactor|review|audit|check|test|verify|ship|find|scan|inspect|look for|search for|homepage|component|page|modal|dialog|form|button|link|menu|navigation|layout)\b/i.test(prompt);
+  return isAction && looksLikeUiWork(prompt);
 }
 
-function selectRequiredSpecialists(prompt) {
+function selectRequiredSpecialists(prompt, surface) {
+  if (surface.primary === "desktop") {
+    const specialists = new Set(["desktop-a11y-specialist", "desktop-a11y-testing-coach"]);
+    if (surface.signals.includes("wxpython")) {
+      specialists.add("wxpython-specialist");
+    }
+    if (surface.signals.includes("nvda-addon")) {
+      specialists.add("nvda-addon-specialist");
+    }
+    return Array.from(specialists);
+  }
+  if (surface.primary === "documents") {
+    const specialists = new Set(["document-accessibility-wizard"]);
+    if (surface.signals.includes("pdf")) specialists.add("pdf-accessibility");
+    if (surface.signals.includes("docx")) specialists.add("word-accessibility");
+    if (surface.signals.includes("xlsx")) specialists.add("excel-accessibility");
+    if (surface.signals.includes("pptx")) specialists.add("powerpoint-accessibility");
+    if (surface.signals.includes("epub")) specialists.add("epub-accessibility");
+    return Array.from(specialists);
+  }
+  if (surface.primary === "markdown") {
+    return ["markdown-a11y-assistant"];
+  }
   const specialists = new Set(["aria-specialist", "keyboard-navigator"]);
   if (/\b(add|build|create|make|new|homepage|page|screen|component|route)\b/i.test(prompt)) {
     specialists.add("alt-text-headings");
@@ -189,6 +225,114 @@ function selectRequiredSpecialists(prompt) {
     }
   }
   return Array.from(specialists);
+}
+
+function detectProjectSurface(input, prompt) {
+  const workspace = workspaceRoot(input);
+  const taskSignals = new Set(promptSignals(prompt));
+  const workspaceSignals = new Set();
+  const files = workspaceFiles(workspace);
+  for (const file of files) {
+    const extension = file.name.split(".").pop()?.toLowerCase();
+    if (["docx", "xlsx", "pptx", "pdf", "epub"].includes(extension)) workspaceSignals.add(extension);
+    if (extension === "md" || file.name.toLowerCase() === "readme") workspaceSignals.add("markdown");
+    if (["jsx", "tsx", "vue", "svelte", "astro", "html", "css", "scss", "sass", "less"].includes(extension)) workspaceSignals.add("web");
+    if (extension === "py") workspaceSignals.add("python");
+  }
+  const pythonSourceHints = readPythonSourceHints(files);
+  const configuration = `${readProjectConfiguration(workspace)}\n${pythonSourceHints}`;
+  if (/\b(wxpython|wx\.|pygame|pyside|pyqt|tkinter|kivy|pyglet|nuitka|pyinstaller)\b/i.test(configuration)) {
+    workspaceSignals.add("desktop");
+  }
+  if (/\bwxpython\b/i.test(configuration)) workspaceSignals.add("wxpython");
+  if (/\b(globalPluginHandler|appModuleHandler|addonHandler|nvdaHelper)\b/i.test(pythonSourceHints)) workspaceSignals.add("nvda-addon");
+  if (/\b(react|next|vite|vue|svelte|astro|angular|nuxt|gatsby)\b/i.test(configuration)) workspaceSignals.add("web");
+
+  const signals = taskSignals.size > 0 ? taskSignals : workspaceSignals;
+  if (signals.has("nvda-addon")) signals.add("desktop");
+  const hasDocuments = ["docx", "xlsx", "pptx", "pdf", "epub"].some((signal) => signals.has(signal));
+  if (signals.has("desktop") || signals.has("python")) return { primary: "desktop", router: "developer-tools", coordinator: "developer-hub", signals: Array.from(signals) };
+  if (hasDocuments) return { primary: "documents", router: "document-accessibility", coordinator: "document-accessibility-wizard", signals: Array.from(signals) };
+  if (signals.has("markdown") && !signals.has("web")) return { primary: "markdown", router: "markdown-accessibility", coordinator: "markdown-a11y-assistant", signals: Array.from(signals) };
+  return { primary: "web", router: "web-accessibility", coordinator: "accessibility-lead", signals: Array.from(signals) };
+}
+
+function promptSignals(prompt) {
+  const signals = [];
+  const text = String(prompt || "").toLowerCase();
+  if (/\b(wxpython|pygame|pyside|pyqt|tkinter|kivy|pyglet|desktop app|native app)\b/.test(text)) signals.push("desktop");
+  if (/\bwxpython\b/.test(text)) signals.push("wxpython");
+  if (/\bnvda(?:[- ](?:add-on|addon)| plugin)\b/.test(text)) signals.push("nvda-addon");
+  if (/\b(react|next\.?js|vue|svelte|astro|web app|web page|html|jsx|tsx)\b/.test(text)) signals.push("web");
+  for (const extension of ["docx", "xlsx", "pptx", "pdf", "epub"]) {
+    if (new RegExp(`\\b${extension}\\b`).test(text)) signals.push(extension);
+  }
+  if (/\b(markdown|readme|\.md\b)\b/.test(text)) signals.push("markdown");
+  return signals;
+}
+
+function workspaceRoot(input) {
+  const candidates = [input.workspace_root, input.workspaceRoot, input.cwd, input.working_directory, input.workingDirectory, process.cwd()];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const resolved = resolve(String(candidate));
+      if (statSync(resolved).isDirectory()) return resolved;
+    } catch {
+      // Try the next hook payload capability or process working directory.
+    }
+  }
+  return null;
+}
+
+function workspaceFiles(workspace) {
+  if (!workspace) return [];
+  const files = [];
+  const ignored = new Set([".git", "node_modules", ".venv", "venv", "dist", "build", ".next"]);
+  const visit = (directory, depth) => {
+    if (depth > 2 || files.length >= 200) return;
+    let entries = [];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (ignored.has(entry.name)) continue;
+      if (entry.isDirectory()) visit(join(directory, entry.name), depth + 1);
+      else files.push({ name: entry.name, path: join(directory, entry.name) });
+      if (files.length >= 200) return;
+    }
+  };
+  visit(workspace, 0);
+  return files;
+}
+
+function readPythonSourceHints(files) {
+  return files
+    .filter((file) => /\.pyw?$/i.test(file.name))
+    .slice(0, 25)
+    .map((file) => {
+      try {
+        return readFileSync(file.path, "utf8").slice(0, 4096);
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+}
+
+function readProjectConfiguration(workspace) {
+  if (!workspace) return "";
+  const files = ["package.json", "pyproject.toml", "requirements.txt", "setup.py", "Pipfile", "Cargo.toml", "go.mod", ".csproj"];
+  return files.map((file) => {
+    const path = join(workspace, file);
+    try {
+      return existsSync(path) ? readFileSync(path, "utf8") : "";
+    } catch {
+      return "";
+    }
+  }).join("\n");
 }
 
 function writeTurnState(value) {
@@ -286,7 +430,19 @@ function isTrackedAgent(agentType) {
     "alt-text-headings",
     "tables-data-specialist",
     "link-checker",
-    "web-accessibility-wizard"
+    "web-accessibility-wizard",
+    "developer-hub",
+    "wxpython-specialist",
+    "nvda-addon-specialist",
+    "desktop-a11y-specialist",
+    "desktop-a11y-testing-coach",
+    "document-accessibility-wizard",
+    "word-accessibility",
+    "excel-accessibility",
+    "powerpoint-accessibility",
+    "pdf-accessibility",
+    "epub-accessibility",
+    "markdown-a11y-assistant"
   ]).has(agentType);
 }
 

--- a/codex-plugin/hooks/hooks.json
+++ b/codex-plugin/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "SubagentStart": [
       {
-        "matcher": "^(accessibility-lead|aria-specialist|keyboard-navigator|contrast-master|forms-specialist|modal-specialist|live-region-controller|alt-text-headings|tables-data-specialist|link-checker|web-accessibility-wizard)$",
+        "matcher": "^(accessibility-lead|aria-specialist|keyboard-navigator|contrast-master|forms-specialist|modal-specialist|live-region-controller|alt-text-headings|tables-data-specialist|link-checker|web-accessibility-wizard|developer-hub|wxpython-specialist|nvda-addon-specialist|desktop-a11y-specialist|desktop-a11y-testing-coach|document-accessibility-wizard|word-accessibility|excel-accessibility|powerpoint-accessibility|pdf-accessibility|epub-accessibility|markdown-a11y-assistant)$",
         "hooks": [
           {
             "type": "command",
@@ -25,7 +25,7 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "^(accessibility-lead|aria-specialist|keyboard-navigator|contrast-master|forms-specialist|modal-specialist|live-region-controller|alt-text-headings|tables-data-specialist|link-checker|web-accessibility-wizard)$",
+        "matcher": "^(accessibility-lead|aria-specialist|keyboard-navigator|contrast-master|forms-specialist|modal-specialist|live-region-controller|alt-text-headings|tables-data-specialist|link-checker|web-accessibility-wizard|developer-hub|wxpython-specialist|nvda-addon-specialist|desktop-a11y-specialist|desktop-a11y-testing-coach|document-accessibility-wizard|word-accessibility|excel-accessibility|powerpoint-accessibility|pdf-accessibility|epub-accessibility|markdown-a11y-assistant)$",
         "hooks": [
           {
             "type": "command",

--- a/scripts/codex-accessibility-dispatch-smoke.mjs
+++ b/scripts/codex-accessibility-dispatch-smoke.mjs
@@ -61,13 +61,17 @@ const hookScript = requireFile(hookScriptPath);
 for (const phrase of [
   "Accessibility Agents Codex dispatch is required",
   "permissionDecision: \"deny\"",
-  "Spawn accessibility-lead first",
+  "turn.coordinator || \"accessibility-lead\"",
   "handleStop",
   "parent_thread_id",
   "hasAgentStateSince",
   "look for",
   "selectRequiredSpecialists",
   "modal-specialist",
+  "detectProjectSurface",
+  "desktop-a11y-specialist",
+  "document-accessibility-wizard",
+  "markdown-a11y-assistant",
 ]) {
   if (!hookScript.includes(phrase)) {
     fail(`${hookScriptPath}: missing dispatch guard phrase "${phrase}".`);

--- a/scripts/test-codex-accessibility-dispatch.mjs
+++ b/scripts/test-codex-accessibility-dispatch.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const root = process.cwd();
+const hook = resolve(root, "codex-plugin/hooks/a11y-codex-dispatch-guard.mjs");
+const fixtures = mkdtempSync(join(tmpdir(), "a11y-codex-dispatch-"));
+
+function makeFixture(name, files) {
+  const directory = join(fixtures, name);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const path = join(directory, relativePath);
+    mkdirSync(resolve(path, ".."), { recursive: true });
+    writeFileSync(path, content);
+  }
+  return directory;
+}
+
+function dispatch(workspace, prompt, payloadKey = "workspace_root") {
+  const output = runHook(workspace, {
+    hook_event_name: "UserPromptSubmit", prompt, session_id: "surface-test", turn_id: "turn-1", [payloadKey]: workspace,
+  });
+  return output?.hookSpecificOutput?.additionalContext || "";
+}
+
+function runHook(workspace, input) {
+  const stdout = execFileSync(process.execPath, [hook], {
+    cwd: workspace,
+    env: { ...process.env, PLUGIN_DATA: join(workspace, ".hook-data") },
+    input: JSON.stringify(input),
+    encoding: "utf8",
+  });
+  return stdout ? JSON.parse(stdout) : "";
+}
+
+function expectAgents(context, expected, unexpected = []) {
+  for (const agent of expected) assert.match(context, new RegExp(`\\b${agent}\\b`));
+  for (const agent of unexpected) assert.doesNotMatch(context, new RegExp(`\\b${agent}\\b`));
+}
+
+try {
+  const web = makeFixture("web", {
+    "package.json": JSON.stringify({ dependencies: { react: "^19.0.0" } }),
+    "src/app.js": "export const App = () => null;",
+  });
+  expectAgents(dispatch(web, "Fix the accessible modal"), ["accessibility-lead", "aria-specialist", "keyboard-navigator", "modal-specialist"]);
+
+  const desktop = makeFixture("desktop", {
+    "pyproject.toml": '[project]\ndependencies = ["wxPython>=4.2"]\n',
+    "src/main.py": "import wx\n",
+  });
+  expectAgents(dispatch(desktop, "Review the UI accessibility", "cwd"), ["developer-hub", "desktop-a11y-specialist", "desktop-a11y-testing-coach", "wxpython-specialist"], ["accessibility-lead", "keyboard-navigator"]);
+
+  const documents = makeFixture("documents", { "report.pdf": "placeholder" });
+  expectAgents(dispatch(documents, "Audit this report for accessibility"), ["document-accessibility-wizard", "pdf-accessibility"], ["accessibility-lead"]);
+
+  const markdown = makeFixture("markdown", { "README.md": "# Guide\n" });
+  expectAgents(dispatch(markdown, "Review the markdown accessibility"), ["markdown-a11y-assistant"], ["accessibility-lead"]);
+
+  const mixed = makeFixture("mixed", { "report.pdf": "placeholder", "pyproject.toml": 'dependencies = ["pygame"]\n' });
+  expectAgents(dispatch(mixed, "Review the React web app accessibility"), ["accessibility-lead", "aria-specialist", "keyboard-navigator"], ["desktop-a11y-specialist", "document-accessibility-wizard"]);
+  expectAgents(dispatch(mixed, "Test the web app with NVDA accessibility"), ["accessibility-lead", "aria-specialist", "keyboard-navigator"], ["nvda-addon-specialist"]);
+
+  const nvda = makeFixture("nvda", { "src/addon.py": "import nvdaHelper\n" });
+  expectAgents(dispatch(nvda, "Review NVDA add-on accessibility"), ["developer-hub", "desktop-a11y-specialist", "desktop-a11y-testing-coach", "nvda-addon-specialist"], ["accessibility-lead"]);
+
+  const python = makeFixture("python", { "app.py": "print('ready')\n", "README.md": "# Command line tool\n" });
+  expectAgents(dispatch(python, "Review the UI accessibility"), ["developer-hub", "desktop-a11y-specialist", "desktop-a11y-testing-coach"], ["markdown-a11y-assistant"]);
+
+  const plain = makeFixture("plain", { "notes.txt": "No framework signal" });
+  assert.equal(dispatch(plain, "Fix this typo"), "");
+
+  const gate = makeFixture("gate", { "pyproject.toml": 'dependencies = ["pygame"]\n', "app.py": "import pygame\n" });
+  dispatch(gate, "Fix the desktop UI accessibility");
+  const blocked = runHook(gate, {
+    hook_event_name: "PreToolUse", session_id: "surface-test", turn_id: "turn-1", tool_input: { patch: "*** Update File: app.py" },
+  });
+  assert.equal(blocked.hookSpecificOutput.permissionDecision, "deny");
+  runHook(gate, {
+    hook_event_name: "SubagentStart", session_id: "surface-test", turn_id: "turn-1", agent_type: "developer-hub",
+  });
+  assert.equal(runHook(gate, {
+    hook_event_name: "PreToolUse", session_id: "surface-test", turn_id: "turn-1", tool_input: { patch: "*** Update File: app.py" },
+  }), "");
+  const incompleteStop = runHook(gate, { hook_event_name: "Stop", session_id: "surface-test", turn_id: "turn-1" });
+  assert.equal(incompleteStop.decision, "block");
+  assert.match(incompleteStop.reason, /developer-hub completion/);
+  assert.doesNotMatch(incompleteStop.reason, /accessibility-lead/);
+  for (const agent_type of ["developer-hub", "desktop-a11y-specialist", "desktop-a11y-testing-coach"]) {
+    runHook(gate, { hook_event_name: "SubagentStop", session_id: "surface-test", turn_id: "turn-1", agent_type });
+  }
+  assert.equal(runHook(gate, { hook_event_name: "Stop", session_id: "surface-test", turn_id: "turn-1" }), "");
+
+  console.log("Codex accessibility project-surface routing tests passed.");
+} finally {
+  rmSync(fixtures, { recursive: true, force: true });
+}

--- a/scripts/validate-codex-plugin.js
+++ b/scripts/validate-codex-plugin.js
@@ -109,6 +109,9 @@ if (fs.existsSync(codexHookPath)) {
     for (const phrase of [
       'a11y-codex-dispatch-guard.mjs',
       'modal-specialist',
+      'desktop-a11y-specialist',
+      'document-accessibility-wizard',
+      'markdown-a11y-assistant',
       'SubagentStop',
       'Stop',
       'apply_patch|Edit|Write',
@@ -130,7 +133,7 @@ if (fs.existsSync(codexHookScript)) {
   for (const phrase of [
     'Accessibility Agents Codex dispatch is required',
     'permissionDecision: "deny"',
-    'Spawn accessibility-lead first',
+    'turn.coordinator || "accessibility-lead"',
     'handleStop',
     'parent_thread_id',
     'hasAgentStateSince',
@@ -139,8 +142,13 @@ if (fs.existsSync(codexHookScript)) {
     'selectRequiredSpecialists',
     'modal-specialist',
     'tool_search',
-    'touchesUiFile',
+    'touchesRelevantFile',
     'looksLikeUiWork',
+    'detectProjectSurface',
+    'workspaceRoot',
+    'desktop-a11y-specialist',
+    'document-accessibility-wizard',
+    'markdown-a11y-assistant',
   ]) {
     if (!body.includes(phrase)) {
       fail(`codex-plugin/hooks/a11y-codex-dispatch-guard.mjs: missing dispatch guard phrase "${phrase}".`);


### PR DESCRIPTION
Routes Codex hook accessibility dispatch from bounded workspace evidence and explicit task targets, instead of treating every UI/accessibility prompt as web work. Desktop and Python work now uses developer-tools coordination with native accessibility and screen-reader testing specialists; document and markdown tasks use their respective coordinators, while web coverage is preserved. Adds lifecycle-aware behavioral routing tests for web, desktop, document, markdown, mixed-project, NVDA, Python, fallback, and Stop-gate cases. Verification passed the project-surface routing test, dispatch source smoke check, Codex plugin validator, agent validator, syntax checks, and diff whitespace check.